### PR TITLE
Switch to loading HTML as file url rather than loading HTML directly as a string

### DIFF
--- a/tasks/js/screenshot.js
+++ b/tasks/js/screenshot.js
@@ -69,9 +69,10 @@ if (puppeteer) {
     let timestamp = Date.now();
     let html = fs.readFileSync(path.join(process.cwd(), args.file), 'utf8');
     let devices = await requireg('puppeteer/DeviceDescriptors');
-    let browser = await puppeteer.launch();
+    let browser = await puppeteer.launch({headless: true});
+    let filepath = `file://${process.cwd()}/`+args.file;
     let page = await browser.newPage();
-    await page.goto( `data:text/html,${html}`, {waitUntil: 'networkidle0'} );
+    await page.goto( filepath, {waitUntil: 'networkidle0'} );
 
     for (let device of config.screenshots.devices) {
       if (!devices[device]) {

--- a/tasks/js/screenshot.js
+++ b/tasks/js/screenshot.js
@@ -69,7 +69,7 @@ if (puppeteer) {
     let timestamp = Date.now();
     let devices = await requireg('puppeteer/DeviceDescriptors');
     let browser = await puppeteer.launch({headless: true});
-    let filepath = `file://${process.cwd()}/`+args.file;
+    let filepath = `file://${process.cwd()}/` + args.file;
     let page = await browser.newPage();
     await page.goto( filepath, {waitUntil: 'networkidle0'} );
 

--- a/tasks/js/screenshot.js
+++ b/tasks/js/screenshot.js
@@ -67,7 +67,6 @@ if (puppeteer) {
 
   (async () => {
     let timestamp = Date.now();
-    let html = fs.readFileSync(path.join(process.cwd(), args.file), 'utf8');
     let devices = await requireg('puppeteer/DeviceDescriptors');
     let browser = await puppeteer.launch({headless: true});
     let filepath = `file://${process.cwd()}/`+args.file;

--- a/tasks/js/screenshot.js
+++ b/tasks/js/screenshot.js
@@ -71,7 +71,7 @@ if (puppeteer) {
     let browser = await puppeteer.launch({headless: true});
     let filepath = `file://${process.cwd()}/` + args.file;
     let page = await browser.newPage();
-    await page.goto( filepath, {waitUntil: 'networkidle0'} );
+    await page.goto(filepath, {waitUntil: 'networkidle0'});
 
     for (let device of config.screenshots.devices) {
       if (!devices[device]) {


### PR DESCRIPTION
This enables relative URLs for testing and also solves some encodeURI issues.  Screenshots were just blank white pages because of encoding issues.