### PR TITLE
fix: media queries order

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,8 +2,8 @@
 module.exports = {
   theme: {
     screens: {
-      xs: {max: '425px'},
       sm: {max: '600px'},
+      xs: {max: '425px'},
     },
     extend: {
       spacing: {


### PR DESCRIPTION
This fixes an issue with the media queries order. They are output in the order defined in `tailwind.config.js`, so `xs` must come after `sm`, otherwise it has no effect.

Fixes maizzle/framework#965